### PR TITLE
Shorten manifest bucket name for Compaction Blueprint

### DIFF
--- a/samples/compaction/layout.py
+++ b/samples/compaction/layout.py
@@ -97,7 +97,7 @@ def generate_layout(user_params, system_params):
 
     # Creating manifest bucket
     if user_params['EnableManifest']:
-        the_manifest_bucket = f"aws-glue-blueprint-compaction-manifest-{system_params['accountId']}-{system_params['region']}"
+        the_manifest_bucket = f"aws-glue-compaction-manifest-{system_params['accountId']}-{system_params['region']}"
         the_manifest_prefix = f"{workflow_name}/"
         the_manifest_location = f"s3://{the_manifest_bucket}/{the_manifest_prefix}"
         try:


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
A bucket with the name `aws-glue-blueprint-compaction-manifest-{accountId}-{region}` is created in the Compaction blueprint [here](https://github.com/awslabs/aws-glue-blueprint-libs/blob/facb155cf31688c33c565aed111e7d9b864d4453/samples/compaction/layout.py#L100), but this fails due to long region names such as `ap-northeast-1` (bucket name becomes 66 characters) when the workflow is kicked.

<img width="571" alt="Screen Shot 2021-11-18 at 13 44 48" src="https://user-images.githubusercontent.com/38214467/142353415-3ae73b3a-0712-46f9-b532-452ab167616f.png">
Shortening the bucket name to prevent the failure of the blueprint.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
