### PR TITLE
(fix) Patch head_bucket calls to include ExpectedBucketOwner

### DIFF
--- a/samples/compaction/layout.py
+++ b/samples/compaction/layout.py
@@ -68,7 +68,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -84,7 +84,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)
@@ -101,7 +101,7 @@ def generate_layout(user_params, system_params):
         the_manifest_prefix = f"{workflow_name}/"
         the_manifest_location = f"s3://{the_manifest_bucket}/{the_manifest_prefix}"
         try:
-            s3_client.head_bucket(Bucket=the_manifest_bucket)
+            s3_client.head_bucket(Bucket=the_manifest_bucket, ExpectedBucketOwner=system_params['accountId'])
             print("Manifest bucket already exists: ", the_manifest_bucket)
         except ClientError as ce:
             print(ce)

--- a/samples/conversion/layout.py
+++ b/samples/conversion/layout.py
@@ -58,7 +58,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -74,7 +74,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)

--- a/samples/custom_connection_to_catalog/layout.py
+++ b/samples/custom_connection_to_catalog/layout.py
@@ -17,10 +17,10 @@ logger.addHandler(handler)
 logger.propagate = False
 
 
-def create_s3_bucket_if_needed(s3_client, bucket_name, region):
+def create_s3_bucket_if_needed(s3_client, bucket_name, region, account_id):
     location = {'LocationConstraint': region}
     try:
-        s3_client.head_bucket(Bucket=bucket_name)
+        s3_client.head_bucket(Bucket=bucket_name, ExpectedBucketOwner=account_id)
         logger.info(f"S3 Bucket already exists: {bucket_name}")
     except ClientError as ce1:
         if ce1.response['Error']['Code'] == "404": # bucket not found
@@ -68,11 +68,11 @@ def generate_layout(user_params, system_params):
 
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
-    create_s3_bucket_if_needed(s3_client, the_script_bucket, system_params['region'])
+    create_s3_bucket_if_needed(s3_client, the_script_bucket, system_params['region'], system_params['accountId'])
 
     # Creating temp bucket
     the_temp_bucket = f"aws-glue-temporary-{system_params['accountId']}-{system_params['region']}"
-    create_s3_bucket_if_needed(s3_client, the_temp_bucket, system_params['region'])
+    create_s3_bucket_if_needed(s3_client, the_temp_bucket, system_params['region'], system_params['accountId'])
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
 

--- a/samples/encoding/layout.py
+++ b/samples/encoding/layout.py
@@ -29,7 +29,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -45,7 +45,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)

--- a/samples/jdbc_to_s3/layout.py
+++ b/samples/jdbc_to_s3/layout.py
@@ -21,7 +21,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -37,7 +37,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)

--- a/samples/partitioning/layout.py
+++ b/samples/partitioning/layout.py
@@ -58,7 +58,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -74,7 +74,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)

--- a/samples/s3_to_dynamodb/layout.py
+++ b/samples/s3_to_dynamodb/layout.py
@@ -21,7 +21,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -37,7 +37,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)

--- a/samples/s3_to_jdbc/layout.py
+++ b/samples/s3_to_jdbc/layout.py
@@ -21,7 +21,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -37,7 +37,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)

--- a/samples/standard_table_to_governed/layout.py
+++ b/samples/standard_table_to_governed/layout.py
@@ -32,7 +32,7 @@ def generate_layout(user_params, system_params):
     # Creating script bucket
     the_script_bucket = f"aws-glue-scripts-{system_params['accountId']}-{system_params['region']}"
     try:
-        s3_client.head_bucket(Bucket=the_script_bucket)
+        s3_client.head_bucket(Bucket=the_script_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Script bucket already exists: ", the_script_bucket)
     except ClientError as ce:
         print(ce)
@@ -48,7 +48,7 @@ def generate_layout(user_params, system_params):
     the_temp_prefix = f"{workflow_name}/"
     the_temp_location = f"s3://{the_temp_bucket}/{the_temp_prefix}"
     try:
-        s3_client.head_bucket(Bucket=the_temp_bucket)
+        s3_client.head_bucket(Bucket=the_temp_bucket, ExpectedBucketOwner=system_params['accountId'])
         print("Temp bucket already exists: ", the_temp_bucket)
     except ClientError as ce:
         print(ce)


### PR DESCRIPTION
 Patch head_bucket calls to include ExpectedBucketOwner. 

Existing sample code is vulnerable to potential bucket sniping due to predicable bucket names. Add additional checks to ensure that buckets are owned by the blueprint owner prior to uploading or downloading information from them. 

*Issue #, if available:*

*Description of changes:*
Update head_bucket calls to use the ExpectedBucketOwner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
